### PR TITLE
fix(build) - Fix build when directories rom and mods don't exist.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -62,12 +62,14 @@
       <arg value="${cmd.con}"/>
       <arg value="asar p ./plugins/OotOnline ${tfolder}/plugins/OotOnline.asar"/>
     </exec>
-    <copy todir="${tfolder}/mods">
+    <copy todir="${tfolder}/mods" failonerror="false">
       <fileset dir="mods" includes="**"/>
     </copy>
-    <copy todir="${tfolder}/rom">
+    <mkdir dir="${tfolder}/mods" />
+    <copy todir="${tfolder}/rom" failonerror="false">
       <fileset dir="rom" includes="**"/>
     </copy>
+    <mkdir dir="${tfolder}/rom" />
     <replace file="${tfolder}/Lua/OotModLoader.lua" propertyFile="build.properties">
       <replacefilter token="@major@" property="major"/>
       <replacefilter token="@minor@" property="minor"/>

--- a/package-lock.json
+++ b/package-lock.json
@@ -662,7 +662,7 @@
       "resolved": "https://registry.npmjs.org/discord-rich-presence/-/discord-rich-presence-0.0.8.tgz",
       "integrity": "sha512-IpVMPjv15C9UvppxvrrGdv6bzQHOW1P1vLoMH15HvdJwGJ3dBd2bnrJ63Uy36YRUfrAMxGLiwUDHncvC8AuPaQ==",
       "requires": {
-        "discord-rpc": "github:discordjs/rpc"
+        "discord-rpc": "github:discordjs/rpc#2dc7ca3e78d632c07ca965a65ba669afe26fdc7f"
       }
     },
     "discord-rpc": {


### PR DESCRIPTION
During the build, an error occured if mods and rom directories don't exist.

I changed the build to skip copying on failure and create directories if they do not exist.